### PR TITLE
Use theme attribute for icon tint

### DIFF
--- a/app/src/main/res/drawable/outline_swap_vert_24.xml
+++ b/app/src/main/res/drawable/outline_swap_vert_24.xml
@@ -1,4 +1,4 @@
-<vector xmlns:android="http://schemas.android.com/apk/res/android" android:height="24dp" android:tint="#000000" android:viewportHeight="960" android:viewportWidth="960" android:width="24dp">
+<vector xmlns:android="http://schemas.android.com/apk/res/android" android:height="24dp" android:tint="?attr/colorControlNormal" android:viewportHeight="960" android:viewportWidth="960" android:width="24dp">
       
     <path android:fillColor="@android:color/white" android:pathData="M320,520L320,233L217,336L160,280L360,80L560,280L503,336L400,233L400,520L320,520ZM600,880L400,680L457,624L560,727L560,440L640,440L640,727L743,624L800,680L600,880Z"/>
     


### PR DESCRIPTION
Fixed an issue where icons remained black when dark mode was enabled.