### PR TITLE
Trigger Android Lint for push to main

### DIFF
--- a/.github/workflows/android-lint.yml
+++ b/.github/workflows/android-lint.yml
@@ -1,6 +1,9 @@
 name: Android Lint
 
 on:
+  push:
+    branches:
+      - main
   pull_request:
     branches:
       - main


### PR DESCRIPTION
Fixed that it was not updated because Android Lint was not running on the main branch.